### PR TITLE
Updated rules for deploy new documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: write


### PR DESCRIPTION
# Changes
- Deployment of documentation also occurs when `mkdocs.yml` and `.github/workflows/docs.yml` change